### PR TITLE
Fix race when commiting packages.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 use semver::Version;
 use serde::Serialize;
 use thiserror::Error;
+use std::io;
 
 #[derive(Debug, Clone, Serialize)]
 struct ErrorMessage {
@@ -169,4 +170,10 @@ impl Error {
 
 impl warp::reject::Reject for Error {
     // nop
+}
+
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Self::Io(e)
+    }
 }


### PR DESCRIPTION
* Wait for files to flush to disk before committing them.
* Replace git glob `*` by `.` which is more efficient (no expension)
    and also includes files whose names being with a dot.

This fixes https://github.com/moriturus/ktra/issues/20.